### PR TITLE
🧹 Remove incomplete event handlers from MultiplayerManager

### DIFF
--- a/src/lib/multiplayer.ts
+++ b/src/lib/multiplayer.ts
@@ -159,18 +159,6 @@ class MultiplayerManager {
       case 'player_moved':
         this.updatePlayerPosition(data);
         break;
-      case 'combat_event':
-        this.handleCombatEvent(data);
-        break;
-      case 'chat_message':
-        this.handleChatMessage(data);
-        break;
-      case 'guild_update':
-        this.handleGuildUpdate(data);
-        break;
-      case 'territory_update':
-        this.handleTerritoryUpdate(data);
-        break;
     }
 
     // Trigger callbacks
@@ -315,26 +303,6 @@ class MultiplayerManager {
       player.velocity = data.velocity;
       player.lastSeen = data.timestamp;
     }
-  }
-
-  private handleCombatEvent(data: any) {
-    // Handle combat events between players
-    console.log('⚔️ Combat event:', data);
-  }
-
-  private handleChatMessage(data: any) {
-    // Handle incoming chat messages
-    console.log('💬 Chat:', data);
-  }
-
-  private handleGuildUpdate(data: any) {
-    // Handle guild-related updates
-    console.log('🏰 Guild update:', data);
-  }
-
-  private handleTerritoryUpdate(data: any) {
-    // Handle territory control changes
-    console.log('🗺️ Territory update:', data);
   }
 
   private calculateDistanceSq(


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed empty, incomplete handler methods (`handleGuildUpdate`, `handleCombatEvent`, `handleChatMessage`, and `handleTerritoryUpdate`) and their associated cases in the `handleMessage` switch statement within `src/lib/multiplayer.ts`. 

💡 **Why:** How this improves maintainability
These methods were purely stub implementations containing only a `console.log` and comments indicating incomplete work. Leaving dead code or unnecessary stubs clutters the file, introduces noise, and adds overhead for future maintainers. The `MultiplayerManager.handleMessage` architecture natively propagates all parsed events to external subscribers using `this.triggerCallbacks(type, data)` directly after the switch case. Removing these empty blocks and relying on the fallthrough safely removes the noise without affecting the intended event-driven functionality.

✅ **Verification:** How you confirmed the change is safe
1. Analyzed the code and found that the stubs executed zero state changes. 
2. Checked how `handleMessage` works and verified that `this.triggerCallbacks(type, data)` runs unconditionally after the `switch` block, ensuring UI components (e.g., chat logs) still correctly receive the messages.
3. Formatted code via `npm run format`.
4. Verified that there were no linting issues via `npm run lint`.
5. Ran test suite via `npm run test` which executed successfully.

✨ **Result:** The improvement achieved
A cleaner, more concise `multiplayer.ts` with 32 lines of unnecessary boilerplate/stub code removed without breaking actual functionality.

---
*PR created automatically by Jules for task [13817829831800655348](https://jules.google.com/task/13817829831800655348) started by @ereezyy*

## Summary by Sourcery

Enhancements:
- Delete no-op event handler methods and their switch cases for combat, chat, guild, and territory updates from the multiplayer manager.